### PR TITLE
Minor fix

### DIFF
--- a/capitulos/creando_un_nuevo_proyecto/README.md
+++ b/capitulos/creando_un_nuevo_proyecto/README.md
@@ -12,5 +12,5 @@ estar seguro de tener Rails instalado.
 
 > **TIP:** Los ejemplos que se muestran a continuación usan `#` y `$` para denotar un
 superuser y user regular de una línea de comandos respectivamente en un sistema
-operativo tipo UNIX. Si estás usando Windows, tú línea de comandos se verá como
+operativo tipo UNIX. Si estás usando Windows, tu línea de comandos se verá como
 `c:\source_code>`.


### PR DESCRIPTION
Needs an update the link. [Lifo's repo] (https://github.com/lifo/docrails/tree/master/guides/code/getting_started) is gone (up to date).